### PR TITLE
Only create policy if permissions are given

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "this" {
 
 resource "aws_iam_role_policy_attachment" "this" {
   role       = aws_iam_role.this.name
-  policy_arn = aws_iam_policy.this.arn
+  policy_arn = aws_iam_policy.this[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "managed_policy" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,8 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_policy" "this" {
-  count       = length(var.policy_documents) > 0 ? 1 : 0
+  count = length(var.policy_documents) > 0 ? 1 : 0
+
   name        = var.policy_name
   description = var.policy_description
   policy      = data.aws_iam_policy_document.permissions_aggregated.json
@@ -21,6 +22,8 @@ resource "aws_iam_policy" "this" {
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
+  count = length(var.policy_documents) > 0 ? 1 : 0
+
   role       = aws_iam_role.this.name
   policy_arn = aws_iam_policy.this[0].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -7,14 +7,15 @@ resource "aws_iam_role" "this" {
 }
 
 resource "aws_iam_policy" "this" {
+  count       = length(var.policy_documents) > 0 ? 1 : 0
   name        = var.policy_name
   description = var.policy_description
   policy      = data.aws_iam_policy_document.permissions_aggregated.json
 
   lifecycle {
     postcondition {
-      condition     = length(data.aws_iam_policy_document.assume_role_aggregated.json) <= 131072
-      error_message = "IAM policies have a maximum size of 131072 characters, got ${length(data.aws_iam_policy_document.assume_role_aggregated.json)}"
+      condition     = length(data.aws_iam_policy_document.permissions_aggregated) <= 131072
+      error_message = "IAM policies have a maximum size of 131072 characters, got ${length(data.aws_iam_policy_document.permissions_aggregated.json)}"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "policy_name" {
   default     = null
 
   validation {
-    condition     = var.policy_name != null && length(var.policy_name) <= 128
+    condition     = var.policy_name != null ? length(var.policy_name) <= 128 : var.policy_name == null
     error_message = "Policy names if given must be <= 128 characters, got ${length(var.policy_name)}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -79,8 +79,8 @@ variable "policy_name" {
   default     = null
 
   validation {
-    condition     = length(var.policy_name) <= 128
-    error_message = "Policy names must be <= 128 characters, got ${length(var.policy_name)}"
+    condition     = var.policy_name != null && length(var.policy_name) <= 128
+    error_message = "Policy names if given must be <= 128 characters, got ${length(var.policy_name)}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,10 +76,10 @@ variable "permissions_boundary" {
 variable "policy_name" {
   description = "The name of the role policy that is visible in the IAM policy manager"
   type        = string
-  default     = null
+  default     = ""
 
   validation {
-    condition     = var.policy_name != null ? length(var.policy_name) <= 128 : var.policy_name == null
+    condition     = length(var.policy_name) <= 128
     error_message = "Policy names if given must be <= 128 characters, got ${length(var.policy_name)}"
   }
 }


### PR DESCRIPTION
# Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Only create an `aws_iam_policy` if explicit permissions are given.

This fixes a bug where if you define a role that uses *only* managed policies, the module will error
